### PR TITLE
Surface more data in the admin tabs

### DIFF
--- a/app/src/Models/GitHub/Organisation.php
+++ b/app/src/Models/GitHub/Organisation.php
@@ -17,5 +17,9 @@ class Organisation extends DataObject
         'Repositories' => Repository::class,
     ];
 
+    private static $summary_fields = [
+        'Name',
+        'Repositories.Count' => '# Repositories',
+    ];
 
 }

--- a/app/src/Models/GitHub/RepoUser.php
+++ b/app/src/Models/GitHub/RepoUser.php
@@ -16,4 +16,11 @@ class RepoUser extends DataObject
         'Repository' => Repository::class,
         'User' => User::class,
     ];
+
+    private static $summary_fields = [
+        'User.Avatar' => 'Avatar',
+        'User.Login' => 'Login',
+        'Repository.Name' => 'Repository',
+        'Roles',
+    ];
 }

--- a/app/src/Models/GitHub/Repository.php
+++ b/app/src/Models/GitHub/Repository.php
@@ -42,6 +42,7 @@ class Repository extends DataObject
     private static $summary_fields = [
         'Name' => 'Name',
         'Organisation.Name' => 'Organisation',
+        'Users.Count' => '# Users',
     ];
 
     public function getCMSFields()

--- a/app/src/Models/GitHub/User.php
+++ b/app/src/Models/GitHub/User.php
@@ -32,6 +32,12 @@ class User extends DataObject
         'Note' => 'Note'
     ];
 
+    private static $searchable_fields = [
+        'Login',
+        'AccessReview',
+        'Note',
+    ];
+
     public function Title()
     {
         return $this->Login;

--- a/app/src/Models/Packagist/Maintainer.php
+++ b/app/src/Models/Packagist/Maintainer.php
@@ -30,6 +30,12 @@ class Maintainer extends DataObject
         'Note' => 'Note'
     ];
 
+    private static $searchable_fields = [
+        'Title',
+        'AccessReview',
+        'Note',
+    ];
+
     public function PackagesCount(): int
     {
         return $this->Packages()->Count();

--- a/app/src/Models/Packagist/Organisation.php
+++ b/app/src/Models/Packagist/Organisation.php
@@ -16,5 +16,8 @@ class Organisation extends DataObject
         'Packages' => Package::class,
     ];
 
-
+    private static $summary_fields = [
+        'Title',
+        'Packages.Count' => '# Packages',
+    ];
 }

--- a/app/src/Models/Packagist/Package.php
+++ b/app/src/Models/Packagist/Package.php
@@ -40,6 +40,7 @@ class Package extends DataObject
     private static $summary_fields = [
         'Title' => 'Title',
         'Organisation.Title' => 'Organisation',
+        'Maintainers.Count' => '# Maintainers',
     ];
 
     public function getCMSFields()

--- a/app/src/Models/Packagist/PackageMaintainer.php
+++ b/app/src/Models/Packagist/PackageMaintainer.php
@@ -17,4 +17,11 @@ class PackageMaintainer extends DataObject
         'Package' => Package::class,
         'Maintainer' => Maintainer::class,
     ];
+
+    private static $summary_fields = [
+        'Maintainer.Avatar' => 'Avatar',
+        'Maintainer.Title' => 'Login',
+        'Package.Name' => 'Repository',
+        'Roles',
+    ];
 }


### PR DESCRIPTION
I found that the "Repo Users" tab especially was useless if it didn't display any summary fields, and users couldn't be searched against at all due to having non-db fields in the summary fields without declaring explicit searchable fields.

These changes should make it easier to see useful information at a glance, and especially for reviewing access from a specific user, the ability to search for that user is 👌